### PR TITLE
Initial implementation of blast-based gene trees.

### DIFF
--- a/bin/mingle
+++ b/bin/mingle
@@ -10,6 +10,7 @@ import IPython
 from mingle.phil_format_database_parser import PhilFormatDatabaseParser
 from mingle.graftm_stockholm_io import GraftMStockholmIterator
 from mingle.taxonomy_string import TaxonomyString
+from mingle.blast_workflow import BlastWorkflow
 from graftm.getaxnseq import Tax_n_Seq_builder
 
 # Inputs:
@@ -17,12 +18,18 @@ from graftm.getaxnseq import Tax_n_Seq_builder
 # HMM => the HMM to search with
 # path to proteome files - one for each genome => sequences to be put into the tree
 default_evalue = '1e-20'
+default_per_identity = 30.0
+default_aln_len = 50.0
+
 parser = argparse.ArgumentParser(description='''For a given HMM, create a phylogenetic tree and "Phil format" .greengenes file from the an ACE genome tree data (after the database info has been extracted)''')
-parser.add_argument('--hmm', help='Hidden Markov model to search with', required=True)
+parser.add_argument('--hmm', help='Hidden Markov model to search with', required=False, default=None)
+parser.add_argument('--query_proteins', help='FASTA file with proteins for identifying homologs', required=False, default=None)
 parser.add_argument('--greengenes', help='.greengenes file to define taxonomy', required=True)
-parser.add_argument('--proteomes_list_file', help='path to file containing faa files of each genome\'s proteome (of the form [path]<ace_ID>[stuff].faa e.g. /srv/home/ben/A00000001.fna.faa', required=True)
+parser.add_argument('--proteomes_list_file', help='path to file containing faa files of each genome\'s proteome (of the form [path]<ace_ID>[stuff].faa e.g. /srv/home/ben/A00000001.fna.faa', required=False)
 parser.add_argument('--preparation_folder', help='store intermediate files in this folder', default=None, required=True)
-parser.add_argument('--evalue', help='evalue cutoff for the hmmsearch (default = %s)' % default_evalue, default=default_evalue)
+parser.add_argument('-e', '--evalue', help='evalue cutoff for identifying homologs (default = %s)' % default_evalue, default=default_evalue)
+parser.add_argument('-p', '--per_identity', help="percent identity for identifying homologs (blast only)", type=float, default=default_per_identity)
+parser.add_argument('-a', '--per_aln_len', help="percent alignment length of query sequence for identifying homologs (blast only)", type=float, default=default_aln_len)
 parser.add_argument('--cpus', type=int, help='number of CPUs to use throughout the process', default=1)
 parser.add_argument('--public', action="store_true", help='Only search proteomes with core_list_status set to public (default = False)', default=False)
 
@@ -51,45 +58,43 @@ def check_taxonomy(tax):
             if 'k__Nanoarchaeota' in tax_set:
                 del tax_set[-1]
                 for idx, item in enumerate(tax_set):
-                        tax_set[idx] = item.replace(tax_suffix[idx],tax_suffix[idx+1])
+                        tax_set[idx] = item.replace(tax_suffix[idx], tax_suffix[idx + 1])
                 return '; '.join(tax_set)
-                
+
             elif 'k__Crenarchaeota' in tax_set:
-                
+
                 if tax_set[2] == 'p__':
-                    del tax_set[-1]    
+                    del tax_set[-1]
                     for idx, item in enumerate(tax_set):
-                        tax_set[idx] = item.replace(tax_suffix[idx],tax_suffix[idx+1])
+                        tax_set[idx] = item.replace(tax_suffix[idx], tax_suffix[idx + 1])
                     return '; '.join(tax_set)
                 elif tax_set[2] == 'p__Thaumarchaeota':
                     del tax_set[4]
                     for idx, item in enumerate(tax_set):
-                        tax_set[idx] = item.replace(item[:3],tax_suffix[idx+1])
-                    return '; '.join(tax_set)    
-                    
+                        tax_set[idx] = item.replace(item[:3], tax_suffix[idx + 1])
+                    return '; '.join(tax_set)
+
                 elif tax_set[2] == 'p__Crenarchaeota':
                     del tax_set[3]
                     for idx, item in enumerate(tax_set):
-                        tax_set[idx] = item.replace(item[:3],tax_suffix[idx+1])
-                    return '; '.join(tax_set)    
-                    
+                        tax_set[idx] = item.replace(item[:3], tax_suffix[idx + 1])
+                    return '; '.join(tax_set)
+
             elif 'k__Euryarchaeota' in tax_set:
                 del tax_set[1]
                 for idx, item in enumerate(tax_set):
-                    tax_set[idx] = item.replace(item[:3],tax_suffix[idx+1])
+                    tax_set[idx] = item.replace(item[:3], tax_suffix[idx + 1])
                 return '; '.join(tax_set)
-                
-            
+
+
             else:
                 print "Bad taxonomy that hasn't been encountered before"
                 exit(0)
-                    
-        
+
+
         else:
             print "Bad taxonomy that hasn't been encountered before"
-            exit(0)  
-
-
+            exit(0)
 
 
 
@@ -99,11 +104,10 @@ if os.path.exists(dump_directory):
     raise Exception("Prep folder %s already exists, cowardly refusing to proceed" % dump_directory)
 os.mkdir(dump_directory)
 
-
 # Read Phil format file, creating a hash of ACE ID to taxonomy
-logging.info('Reading taxonomy information from .greengenes file..')
+logging.info('Reading taxonomy information from .greengenes file.')
 ace_id_to_taxonomy = {}
-ace_id_to_greengenes_hash = {} 
+ace_id_to_greengenes_hash = {}
 ids_used = []
 for entry in PhilFormatDatabaseParser().each(open(options.greengenes)):
     ace_id = entry['db_name']
@@ -116,7 +120,7 @@ for entry in PhilFormatDatabaseParser().each(open(options.greengenes)):
                 ace_id_to_greengenes_hash[ace_id] = entry
             except KeyError:
                 logging.warn("taxonomy information not found in Phil format file for ID: %s, skipping" % ace_id)
-    if not options.public: 
+    if not options.public:
         ids_used.append(entry['db_name'])
         try:
             taxonomy = entry['genome_tree_tax_string']
@@ -128,31 +132,46 @@ for entry in PhilFormatDatabaseParser().each(open(options.greengenes)):
 logging.info("Read in taxonomy for %s genomes" % len(ace_id_to_taxonomy))
 
 
+
+# switch between HMM-mode and BLAST-mode
+# (this is a little hacky right now, we should separate both these workflows into individual files/classes and separate menu options)
+if options.query_proteins:
+    blast_workflow = BlastWorkflow(options.preparation_folder)
+    blast_workflow.run(options.query_proteins,
+                       float(options.evalue),
+                       options.per_identity,
+                       options.per_aln_len,
+                       ace_id_to_greengenes_hash,
+                       options.cpus)
+
+    sys.exit(0)  # break free from HMM workflow [SUPER HACKY]
+
+
 logging.info('Creating simple taxonomy format file..')
 simple_taxonomy_file_path = os.path.join(dump_directory, 'taxonomy.csv')
 with open(simple_taxonomy_file_path, 'w') as taxonomy_fh:
 
     for ace_id, taxes in ace_id_to_taxonomy.items():
         tax = ace_id_to_greengenes_hash[ace_id]['genome_tree_tax_string']
-        
+
         if tax:
             if tax.endswith(';'):
                 tax = tax[:-1]
-                
+
             if TaxonomyString(tax).num_levels() == 7:
                 taxonomy_fh.write(ace_id)
                 taxonomy_fh.write("\t")
-                taxonomy_fh.write(tax) #Need the full path including empty names for tax2tree
+                taxonomy_fh.write(tax)  # Need the full path including empty names for tax2tree
                 taxonomy_fh.write("\n")
             else:
                 logging.warn("Found unexpected number of taxonomy levels in this taxonomy string, not outputing this taxonomy: %s. Attempting to correct..." % tax)
                 tax2 = check_taxonomy(tax)
                 taxonomy_fh.write(ace_id)
                 taxonomy_fh.write("\t")
-                taxonomy_fh.write(tax2) # Need the full path including empty names for tax2tree
+                taxonomy_fh.write(tax2)  # Need the full path including empty names for tax2tree
 
                 taxonomy_fh.write("\n")
-                
+
 logging.info('taxonomy file created.')
 
 logging.info('Create taxit taxonomy and seqinfo file.')
@@ -171,7 +190,7 @@ for f in open(options.proteomes_list_file, 'r'):
 with open(u_proteome_files, 'w') as prot_files:
     for i in ids_files:
         prot_files.write(i)
-    
+
 # Read each of the proteome paths and strip() them
 with open(u_proteome_files) as f:
     proteomes = [pro.strip() for pro in f]
@@ -240,12 +259,12 @@ with open(aligned_sequences_file, 'w') as aligned_sequences_fh:
         seqs = aligned_sequences_from_sto_file(sto_path)
         n_seqs = len(seqs.keys())
         s = [seqs[i] for i in seqs.keys()]
-        
-        
+
+
         try:
             tax = ace_id_to_taxonomy[db_id]
             key_values = ace_id_to_greengenes_hash[db_id]
-        
+
         except KeyError:
             tax = None
             key_values = None
@@ -253,17 +272,17 @@ with open(aligned_sequences_file, 'w') as aligned_sequences_fh:
 
         if n_seqs > 1:
             logging.info("%s has multiple sequences. Renaming..." % (db_id))
-            names = [db_id+'n'+str(x) for x in range(0, n_seqs)]
+            names = [db_id + 'n' + str(x) for x in range(0, n_seqs)]
             duplicates[db_id] = names
         else:
             names = [db_id]
-        
-        
+
+
         for name, seq in zip(names, s):
             aligned_sequences_fh.write(">%s\n" % name)
             aligned_sequences_fh.write("%s\n" % seq)
-            sequence_number += 1 
-            
+            sequence_number += 1
+
             # Writing a mingle readable file
             output_description_hash = {}
             output_description_hash['db_name'] = name
@@ -290,52 +309,31 @@ with open(aligned_sequences_file, 'w') as aligned_sequences_fh:
                                     'core_list_status',
                                     'warning',
                                         ]
-                
+
                 for field in direct_copy_fields:
                     try:
                         output_description_hash[field] = key_values[field]
                     except KeyError:
-                        pass #if it ain't there, don't include it
-            
+                        pass  # if it ain't there, don't include it
+
             greengenes_output_hashes.append(output_description_hash)
 
 
-#Actually write phil readable file
+# Actually write phil readable file
 logging.info("Writing output Phil format file..")
 phil_format_output_file = os.path.join(dump_directory, 'mingle.greengenes')
-
-output_order = [
-                'prokMSA_id',
-                'db_name',
-                'name',
-                'acc',
-                'organism',
-                'genome_tree_description',
-                'owner',
-                'genome_tree_tax_string',
-                'greengenes_tax_string',
-                'blast_hits_16s',
-                'img_tax_string',
-                'img_tax_tax2tree_corrected',
-                'checkm_completeness',
-                'checkm_contamination',
-                'core_list_status',
-                'warning',
-                'aligned_seq',
-                ]
-
 with open(phil_format_output_file, 'w') as f:
-    PhilFormatDatabaseParser().write(greengenes_output_hashes, f, output_order)
+    PhilFormatDatabaseParser().write(greengenes_output_hashes, f)
 
 
 
 
-              
-logging.info("Correcting the sequence names of duplicates in the seq_info file.")     
+
+logging.info("Correcting the sequence names of duplicates in the seq_info file.")
 new_seq = []
 with open(taxtastic_seq, 'r') as f:
     ids = [i.strip().split(',') for i in f]
-    
+
     for i in ids:
         try:
             for new in duplicates[i[0]]:
@@ -346,7 +344,7 @@ with open(taxtastic_seq, 'r') as f:
 with open(taxtastic_seq, 'w') as f:
     for entry in new_seq:
         f.write("%s\n" % entry)
-         
+
 logging.info("Included %s sequences in the alignment" % (sequence_number))
 if sequence_number == 0: raise Exception("No matching sequences detected, cannot create tree")
 if sequence_number < 4: logging.warn("Too few sequences detected (%s)!!!!, the output is unlikely to be informative" % sequence_number)

--- a/mingle/blast.py
+++ b/mingle/blast.py
@@ -1,0 +1,129 @@
+###############################################################################
+#                                                                             #
+#    This program is free software: you can redistribute it and/or modify     #
+#    it under the terms of the GNU General Public License as published by     #
+#    the Free Software Foundation, either version 3 of the License, or        #
+#    (at your option) any later version.                                      #
+#                                                                             #
+#    This program is distributed in the hope that it will be useful,          #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of           #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            #
+#    GNU General Public License for more details.                             #
+#                                                                             #
+#    You should have received a copy of the GNU General Public License        #
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
+#                                                                             #
+###############################################################################
+
+__author__ = "Donovan Parks"
+__copyright__ = "Copyright 2015"
+__credits__ = ["Donovan Parks"]
+__license__ = "GPL3"
+__maintainer__ = "Donovan Parks"
+__email__ = "donovan.parks@gmail.com"
+__status__ = "Development"
+
+import os
+import sys
+import logging
+import subprocess
+
+
+class BlastRunner():
+    """Wrapper for running blast."""
+
+    def __init__(self):
+        """Initialization."""
+        self.logger = logging.getLogger()
+
+        self._check_for_blast()
+
+    def blastp(self, query_seqs, prot_db, evalue, cpus, output_file):
+        """Apply blastp to query file.
+
+        Finds homologs to query sequences using blastp homology search
+        against a protein database.
+
+        Parameters
+        ----------
+        query_seqs : str
+            File containing query sequences.
+        prot_db : str
+            File containing blastp formatted database.
+        evalue : float
+            E-value threshold used to identify homologs.
+        cpus : int
+            Number of cpus to use during homology search.
+        output_file : str
+            Output file containing blastp results.
+        """
+
+        cmd = "blastp -num_threads %d" % cpus
+        cmd += " -query %s -db %s -out %s -evalue %s" % (query_seqs, prot_db, output_file, str(evalue))
+        cmd += " -outfmt '6 qseqid qlen sseqid slen length pident evalue bitscore'"
+        os.system(cmd)
+
+    def _check_for_blast(self):
+        """Check to see if blastp is on the system before we try to run it."""
+
+        # Assume that a successful blast -help returns 0 and anything
+        # else returns non-zero
+        try:
+            subprocess.call(['blastp', '-help'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
+        except:
+            self.logger.error("  [Error] Make sure blastp is on your system path.")
+            sys.exit()
+
+
+class BlastParser():
+    """Parses output files produced with BlastRunner."""
+
+    def __init__(self):
+        """Initialization."""
+        pass
+
+    def identify_homologs(self, blast_table, evalue_threshold, per_identity_threshold, per_aln_len_threshold):
+        """Identify homologs among  blast hits.
+
+        Identifies hits satisfying the criteria required for a
+        gene to be considered a homolog.
+
+        Parameters
+        ----------
+        blast_table : str
+            File containing blast hits in the custom tabular format produced by BlastRunner.
+        evalue_threshold : float
+            E-value threshold used to define homologous gene.
+        per_identity_threshold : float
+            Percent identity threshold used to define a homologous gene.
+        per_aln_len_threshold : float
+            Alignment length threshold used to define a homologous gene.
+
+        Returns
+        -------
+        set
+            Identifiers for homologous genes.
+        """
+
+        homologs = set()
+        for line in open(blast_table):
+            line_split = line.split('\t')
+
+            _query_seq_id = line_split[0]
+            query_len = int(line_split[1])
+
+            sub_seq_id = line_split[2]
+            _subject_len = int(line_split[3])
+
+            aln_len = int(line_split[4])
+            per_ident = float(line_split[5])
+            evalue = float(line_split[6])
+            _bitscore = float(line_split[7])
+
+            if evalue <= evalue_threshold and per_ident >= per_identity_threshold:
+                per_aln_len = aln_len * 100.0 / query_len
+
+                if per_aln_len >= per_aln_len_threshold:
+                    homologs.add(sub_seq_id)
+
+        return homologs

--- a/mingle/blast_workflow.py
+++ b/mingle/blast_workflow.py
@@ -1,0 +1,190 @@
+###############################################################################
+#                                                                             #
+#    This program is free software: you can redistribute it and/or modify     #
+#    it under the terms of the GNU General Public License as published by     #
+#    the Free Software Foundation, either version 3 of the License, or        #
+#    (at your option) any later version.                                      #
+#                                                                             #
+#    This program is distributed in the hope that it will be useful,          #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of           #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            #
+#    GNU General Public License for more details.                             #
+#                                                                             #
+#    You should have received a copy of the GNU General Public License        #
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
+#                                                                             #
+###############################################################################
+
+__author__ = "Donovan Parks"
+__copyright__ = "Copyright 2014"
+__credits__ = ["Donovan Parks"]
+__license__ = "GPL3"
+__maintainer__ = "Donovan Parks"
+__email__ = "donovan.parks@gmail.com"
+__status__ = "Development"
+
+import os
+import sys
+import logging
+from collections import defaultdict
+
+from mingle.blast import BlastRunner, BlastParser
+from mingle.muscle import MuscleRunner
+from mingle.fasttree import FastTreeRunner
+from mingle.phil_format_database_parser import PhilFormatDatabaseParser
+from mingle.seq_io import SeqIO
+
+
+class BlastWorkflow():
+    """Blast-based workflow for building a gene tree."""
+
+    def __init__(self, output_dir):
+        """Initialization."""
+
+        self.logger = logging.getLogger()
+
+        self.protein_seqs = '/srv/whitlam/bio/db/gtdb/prodigal/gtdb.genes.faa'
+        self.protein_blast_db = '/srv/whitlam/bio/db/gtdb/blast/prot/gtdb.genes.faa'
+
+        self.nucleotide_seqs = '/srv/whitlam/bio/db/gtdb/prodigal/gtdb.genes.fna'
+        self.nucleotide_blast_db = '/srv/whitlam/bio/db/gtdb/blast/prot/gtdb.genes.fna'
+
+        self.blast_output = os.path.join(output_dir, "blast_out.tsv")
+
+        self.arb_greengenes_db = os.path.join(output_dir, 'gene_tree.greengenes')
+
+        self.homolog_output = os.path.join(output_dir, "homologs.faa")
+        self.msa_output = os.path.join(output_dir, "homologs.aligned.faa")
+        self.msa_log = os.path.join(output_dir, "homologs.aligned.log")
+
+        self.tree_output = os.path.join(output_dir, "gene_tree.tree")
+        self.tree_log = os.path.join(output_dir, "gene_tree.log")
+        self.tree_output_log = os.path.join(output_dir, "gene_tree.out")
+
+    def modify_greengene_hashes(self, greengenes_metadata, seqs):
+        """Extract and modify GreenGene hashes for homologous genes.
+
+        Provides sensible names for homologous genes which make the
+        source genome clear and handles instances where a genome
+        contains multiple homologous genes. A list of GreenGenes style
+        dictionaries describing the genomes with hits is produced along
+        with a corresponding dictionary of the renamed homologous
+        sequences.
+
+        Parameters
+        ----------
+        greengenes_metadata : dict[genome_id] -> metadata dictionary
+            GreenGenes style metadata for genomes.
+        seqs: dict[seq_id] -> seq
+            Homologous sequences indexed by sequence id.
+
+        Returns
+        -------
+        list of dict
+           Metadata in GreenGenes format for each homologous gene.
+        dict
+            Homologous sequences indexed with new sequence ids.
+        """
+
+        """"""
+        metadata_for_homologs = []
+        genes_in_genome = defaultdict(int)
+        new_seqs = {}
+        for seq_id, seq in seqs.iteritems():
+            # get has for genome
+            genome_id = seq_id.split('_')[0]
+
+            # create hash for gene
+            new_genome_id = genome_id
+
+            count = genes_in_genome[genome_id]
+            if count != 0:
+                new_genome_id += '_' + str(count + 1)
+
+            try:
+                new_hash = greengenes_metadata[genome_id].copy()
+            except:
+                self.logger.warning('Missing metadata information for genome: %s' % genome_id)
+                new_hash = {}
+
+            new_hash['db_name'] = new_genome_id
+            new_hash['prokMSA_id'] = new_genome_id
+            new_hash['name'] = new_genome_id
+            new_hash['acc'] = seq_id
+
+            metadata_for_homologs.append(new_hash)
+
+            genes_in_genome[genome_id] += 1
+
+            # save sequence with new name
+            new_seqs[new_genome_id] = seq
+
+        return metadata_for_homologs, new_seqs
+
+    def run(self, query_seqs, evalue, per_identity, per_aln_len, greengenes_metadata, cpus):
+        """Infer a gene tree for homologous genes identified by blast.
+
+        Complete workflow for inferring a gene tree from homologous sequences
+        to a set of query sequences. Homologous sequences are identified by blast
+        search and a set of user-defined parameters.
+
+        Parameters
+        ----------
+        query_seqs : str
+            Fasta file containing query sequences.
+        evalue : float
+            E-value threshold used to define homologous gene.
+        per_identit : float
+            Percent identity threshold used to define a homologous gene.
+        per_aln_len : float
+            Alignment length threshold used to define a homologous gene.
+        greengenes_metadata : dict[genome_id] -> metadata dictionary
+            GreenGenes style metadata for genomes.
+        cpus : int
+            Number of cpus to use during homology search.
+        """
+
+        if not os.path.exists(query_seqs):
+            self.logger.error('Missing query sequences file: %s' % query_seqs)
+            sys.exit()
+
+        seq_io = SeqIO()
+
+        # identify homologous genes using blast
+        self.logger.info('Identifying homologous genes using blastp.')
+        br = BlastRunner()
+        br.blastp(query_seqs, self.protein_blast_db, evalue, cpus, self.blast_output)
+
+        bp = BlastParser()
+        homologs = bp.identify_homologs(self.blast_output, evalue, per_identity, per_aln_len)
+        self.logger.info('  Identified %d homologous genes.' % len(homologs))
+
+        # extract homologous sequences
+        self.logger.info('Extracting homologous sequences.')
+        seqs = seq_io.extract_seqs(self.protein_seqs, homologs)
+
+        # create GreenGenes style file for ARB
+        self.logger.info('Creating GreenGenes-style file for ARB.')
+        db = PhilFormatDatabaseParser()
+        metadata_for_homologs, new_seqs = self.modify_greengene_hashes(greengenes_metadata, seqs)
+        seq_io.write_fasta(new_seqs, self.homolog_output)
+
+        # infer multiple sequence alignment
+        self.logger.info('Inferring multiple sequence alignment.')
+        mr = MuscleRunner()
+        mr.run(self.homolog_output, self.msa_output, self.msa_log)
+        aligned_seqs = seq_io.read_fasta(self.msa_output)
+
+        # finish constructing out GreenGenes style ARB file
+        for metadata in metadata_for_homologs:
+            gene_id = metadata['db_name']
+            metadata['aligned_seq'] = aligned_seqs[gene_id]
+
+        f = open(self.arb_greengenes_db, 'w')
+        db.write(metadata_for_homologs, f)
+        f.close()
+
+        # infer tree
+        self.logger.info('Inferring gene tree.')
+        ft = FastTreeRunner(multithreaded=(cpus > 1))
+        ft.run(self.msa_output, 'wag', self.tree_output, self.tree_log, self.tree_output_log)

--- a/mingle/fasttree.py
+++ b/mingle/fasttree.py
@@ -1,0 +1,86 @@
+###############################################################################
+#                                                                             #
+#    This program is free software: you can redistribute it and/or modify     #
+#    it under the terms of the GNU General Public License as published by     #
+#    the Free Software Foundation, either version 3 of the License, or        #
+#    (at your option) any later version.                                      #
+#                                                                             #
+#    This program is distributed in the hope that it will be useful,          #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of           #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            #
+#    GNU General Public License for more details.                             #
+#                                                                             #
+#    You should have received a copy of the GNU General Public License        #
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
+#                                                                             #
+###############################################################################
+
+import os
+import sys
+import logging
+
+__author__ = "Donovan Parks"
+__copyright__ = "Copyright 2015"
+__credits__ = ["Donovan Parks"]
+__license__ = "GPL3"
+__maintainer__ = "Donovan Parks"
+__email__ = "donovan.parks@gmail.com"
+__status__ = "Development"
+
+
+class FastTreeRunner():
+    """Wrapper for running FastTree."""
+
+    def __init__(self, multithreaded=True):
+        """Initialization."""
+        self.logger = logging.getLogger()
+
+        self._check_for_fasttree()
+
+        self.multithreaded = multithreaded
+
+    def run(self, msa_file, model_str, output_tree, output_tree_log, log_file=None):
+        """Infer tree using FastTree.
+
+        Parameters
+        ----------
+        msa_file : str
+            Fasta file containing multiple sequence alignment.
+        model_str : str
+            Specified either the 'wag' or 'jtt' model.
+        output_tree: str
+            Output file containing inferred tree.
+        output_tree_log: str
+            Output file containing information about inferred tree.
+        output_log: str
+            Output file containing information about running of FastTree.
+        """
+
+        if model_str.upper() == 'JTT':
+            model_str = ''
+        elif model_str.upper() == 'WAG':
+            model_str = '-wag'
+
+        if not log_file:
+            log_file = '/dev/null'
+
+        cmd = '-quiet -nosupport -gamma %s -log %s %s > %s 2> %s' % (model_str, output_tree_log, msa_file, output_tree, log_file)
+        if self.multithreaded:
+            cmd = 'FastTreeMP ' + cmd
+            os.system(cmd)
+        else:
+            cmd = 'FastTree ' + cmd
+            os.system(cmd)
+
+    def _check_for_fasttree(self):
+        """Check to see if FastTree is on the system path."""
+
+        try:
+            exit_status = os.system('FastTree 2> /dev/null')
+        except:
+            print "Unexpected error!", sys.exc_info()[0]
+            raise
+
+        if exit_status != 0:
+            print "[Error] FastTree is not on the system path."
+            sys.exit()

--- a/mingle/muscle.py
+++ b/mingle/muscle.py
@@ -1,0 +1,70 @@
+###############################################################################
+#                                                                             #
+#    This program is free software: you can redistribute it and/or modify     #
+#    it under the terms of the GNU General Public License as published by     #
+#    the Free Software Foundation, either version 3 of the License, or        #
+#    (at your option) any later version.                                      #
+#                                                                             #
+#    This program is distributed in the hope that it will be useful,          #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of           #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            #
+#    GNU General Public License for more details.                             #
+#                                                                             #
+#    You should have received a copy of the GNU General Public License        #
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
+#                                                                             #
+###############################################################################
+
+__author__ = "Donovan Parks"
+__copyright__ = "Copyright 2015"
+__credits__ = ["Donovan Parks"]
+__license__ = "GPL3"
+__maintainer__ = "Donovan Parks"
+__email__ = "donovan.parks@gmail.com"
+__status__ = "Development"
+
+import os
+import sys
+import logging
+import subprocess
+
+
+class MuscleError(BaseException):
+    pass
+
+
+class MuscleRunner():
+    """Wrapper for running muscle."""
+
+    def __init__(self):
+        """Initialization."""
+        self.logger = logging.getLogger()
+
+        self._check_for_muscle()
+
+    def run(self, seqs, output_file, log_file):
+        """Apply muscle to query sequences.
+
+        Parameters
+        ----------
+        seqs : dict[seq_id] -> seq
+            Sequence to alignment.
+        output_file: str
+            Output file containing multiple sequence alignment.
+        log_file: str
+            Output file containing information about running of muscle.
+        """
+
+        cmd = 'muscle -quiet -in %s -out %s -log %s' % (seqs, output_file, log_file)
+        os.system(cmd)
+
+    def _check_for_muscle(self):
+        """Check to see if muscle is on the system before we try to run it."""
+
+        # Assume that a successful blast -help returns 0 and anything
+        # else returns non-zero
+        try:
+            subprocess.call(['muscle', '-h'], stdout=open(os.devnull, 'w'), stderr=subprocess.STDOUT)
+        except:
+            self.logger.error("  [Error] Make sure muscle is on your system path.")
+            sys.exit()

--- a/mingle/phil_format_database_parser.py
+++ b/mingle/phil_format_database_parser.py
@@ -25,58 +25,79 @@
 #
 # The particular keys are not necessarily as above, just the = BEGIN/END and general layout
 class PhilFormatDatabaseParser:
+    def __init__(self):
+        self.output_order = [
+                        'prokMSA_id',
+                        'db_name',
+                        'name',
+                        'acc',
+                        'organism',
+                        'genome_tree_description',
+                        'owner',
+                        'genome_tree_tax_string',
+                        'greengenes_tax_string',
+                        'blast_hits_16s',
+                        'img_tax_string',
+                        'img_tax_tax2tree_corrected',
+                        'checkm_completeness',
+                        'checkm_contamination',
+                        'core_list_status',
+                        'warning',
+                        'aligned_seq',
+                        ]
+
     def each(self, file_handle):
         # state machine - are we inside or outside a BEGIN/END block
         state = 'outside'
         current_hash = {}
-        
+
         for line_number, line in enumerate(file_handle):
             line = line.strip()
             # print "*%s*" % line
-            if len(line) == 0: continue
-        
+            if len(line) == 0:
+                continue
+
             if line == 'BEGIN':
                 if state == 'outside':
                     state = 'inside'
                     current_hash = {}
                 else:
                     raise Exception("Badly formatted file type 1 on line %s, cannot continue, errored out at this line: %s" % (line_number + 1, line))
-                
+
             elif line == 'END':
                 if state == 'inside':
                     yield current_hash
                     state = 'outside'
                 else:
                     raise Exception("Badly formatted file type 2 on line %s, cannot continue, errored out at this line: %s" % (line_number + 1, line))
-                
+
             elif state == 'inside':
                 splits = line.split('=', 1)
                 if len(splits) == 2:
                     current_hash[splits[0]] = splits[1]
                 else:
                     raise Exception("Badly formatted file type 3 on line %s, cannot continue, errored out at this line: %s" % (line_number + 1, line))
-            
+
             else:
                 raise Exception("Badly formatted file type 4 on line %s, cannot continue, errored out at this line: %s" % (line_number + 1, line))
-            
+
         if state != 'outside':
             raise Exception("Badly formatted file type 5 on line %s, cannot continue, errored out at the end of the file (ended while expecting an END)" % (line_number + 1))
 
-    def write(self, hashes, io, output_order):
+    def write(self, hashes, io):
         is_first = True
         for dahash in hashes:
             if is_first:
                 is_first = False
             else:
                 io.write('\n')
-                
+
             io.write('BEGIN\n')
-            for key in output_order:
+            for key in self.output_order:
                 try:
                     io.write('='.join([key, dahash[key]]))
                     io.write('\n')
                 except KeyError:
-                    if key=='warning':
-                        io.write("warning=\n") #needed for arb parsing
+                    if key == 'warning':
+                        io.write("warning=\n")  # needed for arb parsing
             io.write('END\n')
-

--- a/mingle/seq_io.py
+++ b/mingle/seq_io.py
@@ -1,0 +1,132 @@
+###############################################################################
+#                                                                             #
+#    This program is free software: you can redistribute it and/or modify     #
+#    it under the terms of the GNU General Public License as published by     #
+#    the Free Software Foundation, either version 3 of the License, or        #
+#    (at your option) any later version.                                      #
+#                                                                             #
+#    This program is distributed in the hope that it will be useful,          #
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of           #
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the            #
+#    GNU General Public License for more details.                             #
+#                                                                             #
+#    You should have received a copy of the GNU General Public License        #
+#    along with this program. If not, see <http://www.gnu.org/licenses/>.     #
+#                                                                             #
+###############################################################################
+
+__author__ = "Donovan Parks"
+__copyright__ = "Copyright 2015"
+__credits__ = ["Donovan Parks"]
+__license__ = "GPL3"
+__maintainer__ = "Donovan Parks"
+__email__ = "donovan.parks@gmail.com"
+__status__ = "Development"
+
+import sys
+import gzip
+import logging
+
+
+class SeqIO():
+    """Methods for reading and writing sequence files."""
+
+    def __init__(self):
+        """Initialization."""
+        self.logger = logging.getLogger()
+
+    def read_fasta(self, fasta_file):
+        """Read sequences from fasta file.
+
+        Parameters
+        ----------
+        fasta_file : str
+            Name of fasta file to read.
+
+        Returns
+        -------
+        dict
+            Dictionary of sequences indexed by sequence id.
+        """
+
+        try:
+            if fasta_file.endswith('.gz'):
+                openFile = gzip.open
+            else:
+                openFile = open
+
+            seqs = {}
+            for line in openFile(fasta_file):
+                # skip blank lines
+                if not line.strip():
+                    continue
+
+                if line[0] == '>':
+                    seqId = line[1:].split(None, 1)[0]
+                    seqs[seqId] = []
+                else:
+                    seqs[seqId].append(line[0:-1])
+
+            for seqId, seq in seqs.iteritems():
+                seqs[seqId] = ''.join(seq)
+        except:
+            logger = logging.getLogger()
+            logger.error("  [Error] Failed to process sequence file: " + fasta_file)
+            sys.exit()
+
+        return seqs
+
+    def write_fasta(self, seqs, output_file):
+        """Write sequences to fasta file.
+
+        Parameters
+        ----------
+        seqs : dict
+            Dictionary of sequences indexed by sequence id.
+        output_file : str
+            Name of fasta file to produce.
+        """
+
+        if output_file.endswith('.gz'):
+            fout = gzip.open(output_file, 'wb')
+        else:
+            fout = open(output_file, 'w')
+
+        for seq_id, seq in seqs.iteritems():
+            fout.write('>' + seq_id + '\n')
+            fout.write(seq + '\n')
+        fout.close()
+
+    def extract_seqs(self, fasta_file, seqs_to_extract):
+        """Extract specific sequences from fasta file.
+
+        Parameters
+        ----------
+        fasta_file : str
+            Fasta file containing sequences.
+        seqs_to_extract : set
+            Ids of sequences to extract.
+
+        Returns
+        -------
+        dict
+            Dictionary of sequences indexed by sequence id.
+        """
+
+        seqs = {}
+
+        for line in open(fasta_file):
+            if line[0] == '>':
+                seq_id = line[1:].partition(' ')[0]
+
+                seq_of_interest = False
+                if seq_id in seqs_to_extract:
+                    seqs[seq_id] = []
+                    seq_of_interest = True
+            elif seq_of_interest:
+                seqs[seq_id].append(line[0:-1])
+
+        for seq_id, seq in seqs.iteritems():
+            seqs[seq_id] = ''.join(seq)
+
+        return seqs


### PR DESCRIPTION
- adds several files to support blast-based inference of gene trees
- modified mingle interface to support this new workflow

My development environment enforces PEP8 compliance. As such, a number of minor modification were automatically made within mingle.py and phil_format_database_parser.py (e.g., spaces before and after addition operators). Hopefully this is cool. Personally, I don't love the PEP8 style, but I do think it helps with reading code to have a uniform style and PEP8 seems to be the most popular style guide.
