### PR TITLE
Forced blast to return all hits, not just first 500.

### DIFF
--- a/mingle/blast.py
+++ b/mingle/blast.py
@@ -60,6 +60,7 @@ class BlastRunner():
 
         cmd = "blastp -num_threads %d" % cpus
         cmd += " -query %s -db %s -out %s -evalue %g" % (query_seqs, prot_db, output_file, evalue)
+        cmd += " -max_target_seqs 500000" # ensure all hits are returned
         cmd += " -outfmt '6 qseqid qlen sseqid slen length pident evalue bitscore'"
         os.system(cmd)
 


### PR DESCRIPTION
Fix for issue #14. I've just hard coded the max sequences to return to 500000. This seems reasonable in the context of mingle, though is obviously rubbish in general.
